### PR TITLE
Adds instructions on how to use QuestPDF in Blazor WebAssembly

### DIFF
--- a/patterns-and-practices.md
+++ b/patterns-and-practices.md
@@ -211,6 +211,32 @@ When you get the exception `Unable to load shared library 'libSkiaSharp' or one 
 
 For example: the SkiaSharp.NativeAssets.Linux.NoDependencies nuget ensures that the libSkiaSharp.so file is published and available.
 
+## Support for custom environments (Blazor WebAssembly)
+
+The QuestPDF library has a dependency called SkiaSharp which is used to render the final PDF file. 
+QuestPDF works without problems in Blazor WebAssembly but you need to provide a suitable version of SkiaSharp on runtime. 
+
+**Note:** The tools used in this section are in a prerelease state, they should be used with caution.
+
+First you need to install the WebAssembly tools, that will be used to compile the Skia dependencies to WebAssembly. In a command shell, execute
+
+```
+dotnet workload install wasm-tools
+```
+
+Then you will need to add the SkiaSharp.Views.Blazor Nuget package to your project. SkiaSharp is a crossplatform graphics library based on Skia.
+
+```
+dotnet add package –-prerelease SkiaSharp.Views.Blazor
+```
+
+Subsecuent builds can be slower as the toolchain now compiles Skia to WebAssembly.
+
+Another thing to consider is that WebAssembly code runs on a secured sandbox and it can't access system fonts.
+For this reason any PDF created with QuestPDF in Blazor WebAssembly will not embed the used fonts. The final font used for rendering will be determined by the PDF viewer.
+However you can use a custom font as shown in the section **Accessing custom fonts**.
+
+
 ## Accessing custom fonts
 
 The QuestPDF library has access to all fonts installed on the hosting system. Sometimes though, you don't have control over fonts installed on the production environment. Or you may want to use self-hosted fonts that come with your application as files or embedded resources. In such case, you need to register those fonts as follows:


### PR DESCRIPTION
As discussed in 
https://github.com/QuestPDF/QuestPDF/issues/67
this pull request documents how to use QuestPDF in Blazor WebAssembly.

It mentions all external dependencies required and how to get them. I also built a sample to show that it works in
https://github.com/pablopioli/Blazor-QuestPDF
