### PR TITLE
Grammar fix

### DIFF
--- a/patterns-and-practices.md
+++ b/patterns-and-practices.md
@@ -115,7 +115,7 @@ row.ConstantItem(8, Unit.Centimetre)
 
 ## Execution order
 
-QuestPDF uses FluentAPI and method chaining to describe document's content. It is very important to remember that order of methods os strict. That means, in many cases, changing order of invocations will produce different results. To better understand this behavior, let's analyse this simple example:
+QuestPDF uses FluentAPI and method chaining to describe document's content. It is very important to remember that order of methods is strict. That means, in many cases, changing order of invocations will produce different results. To better understand this behavior, let's analyse this simple example:
 
 ```csharp{7-8,13-14}
 .Row(row =>


### PR DESCRIPTION
Fix a misspelling: `os strict` => `is strict`