### PR TITLE
Fix semicolon and warnings on implementing-charts.md

### DIFF
--- a/docs/examples/implementing-charts.md
+++ b/docs/examples/implementing-charts.md
@@ -39,9 +39,9 @@ var entries = new[]
 {
     var titleStyle = TextStyle
         .Default
-        .Size(20)
+        .FontSize(20)
         .SemiBold()
-        .Color(Colors.Blue.Medium);
+        .FontColor(Colors.Blue.Medium);
 
     column
         .Item()

--- a/docs/examples/implementing-charts.md
+++ b/docs/examples/implementing-charts.md
@@ -41,7 +41,7 @@ var entries = new[]
         .Default
         .Size(20)
         .SemiBold()
-        .Color(Colors.Blue.Medium)
+        .Color(Colors.Blue.Medium);
 
     column
         .Item()


### PR DESCRIPTION
Good morning,

reading your docs I found two things to fix:

- There was a missing semicolon that does not permit to compile the code
- `TextStyle` was using deprecated extension methods