### PR TITLE
Fix syntax error: missing comma

### DIFF
--- a/docs/concepts/document-metadata.md
+++ b/docs/concepts/document-metadata.md
@@ -19,7 +19,7 @@ Document
         Subject = "Invoice for services",
         Keywords = "invoice, services, payment",
         Creator = "MyApplication",
-        Producer = "PdfRpt"
+        Producer = "PdfRpt",
         Language = "en-US",
         CreationDate = DateTimeOffset.Now,
         ModifiedDate = DateTimeOffset.Now


### PR DESCRIPTION
This pull request makes a small update to the `Document` metadata example in the `docs/concepts/document-metadata.md` file. The change adds a comma after the `Producer` field to ensure correct syntax in the code sample.